### PR TITLE
Implementing range download

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -66,6 +66,8 @@ directory of the user with a brief description
 
 If it has been downloaded, will not do anything
 
+This command will work even if you have not run --update-db yet.
+
 ``--download=XKCDNUMBER``
 -------------------------
 


### PR DESCRIPTION
Other changes:

* Documenting --download-latest behavior.
Works without --update-db.

* XKCD_DICT did not need to be global.
Making it local also made the need to retrieve
from the .json file in each command more obvious.

* Also added a check for if a comic number is valid.

* Making utility fxn for downloading a single comic.
This will be done multiple times in the range,
so it's convenient to just have a method for it.