### PR TITLE
Adding custom --path=PATH

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -118,6 +118,21 @@ and store them under the home directory of the user.
     ....
     ....
 
+``--path=PATH``
+---------------
+
+To use a custom directory to store your xkcd_archive, you can append
+--path=./any/path/here to the end of any download method. Absolute and relative
+paths work, but the directory must already exist.
+
+.. code:: bash
+    $ xkcd-dl --download=3 --path=comic
+    Downloading xkcd from 'http://xkcd.com/3/' and storing it under '/home/tasdik/comic/xkcd_archive/3'
+    $ xkcd-dl --download-range 54 56 --path=/home/tasdik/xkcd
+    Downloading xkcd from 'http://xkcd.com/54/' and storing it under '/home/tasdik/xkcd/xkcd_archive/54'
+    Downloading xkcd from 'http://xkcd.com/55/' and storing it under '/home/tasdik/xkcd/xkcd_archive/55'
+    Downloading xkcd from 'http://xkcd.com/56/' and storing it under '/home/tasdik/xkcd/xkcd_archive/56'
+
 Demo
 ====
 
@@ -189,10 +204,10 @@ Help menu:
 
     Usage:
       xkcd-dl --update-db
-      xkcd-dl --download-latest
-      xkcd-dl --download=XKCDNUMBER
-      xkcd-dl --downoad-range <START> <END>
-      xkcd-dl --download-all
+      xkcd-dl --download-latest [--path=PATH]
+      xkcd-dl --download=XKCDNUMBER [--path=PATH]
+      xkcd-dl --downoad-range <START> <END> [--path=PATH]
+      xkcd-dl --download-all [--path=PATH]
       xkcd-dl --version
       xkcd-dl (-h | --help)
     Options:
@@ -227,9 +242,8 @@ To-do
 -  [x] add ``xkcd-dl --download-latest``
 -  [x] add ``xkcd-dl --download=XKCDNUMBER``
 -  [x] add ``xkcd-dl --download-all``
--  [x] add
-   ``xkcd-dl download-range <START> <END>``
-   [ ] add path setting with ``[--path=/path/to/directory]`` option
+-  [x] add ``xkcd-dl download-range <START> <END>``
+-  [x] add path setting with ``[--path=/path/to/directory]`` option
 -  [ ] Remove redundant code in ``download_xkcd_number()``,
    ``download_latest()`` and ``download_all()`` (**Refactoring!!**)
 -  [ ] Adding support to open a particular xkcd at the CLI itself.

--- a/xkcd_dl/cli.py
+++ b/xkcd_dl/cli.py
@@ -4,10 +4,10 @@ r'''
 Run `xkcd-dl --update-db` if running for the first time.
 Usage:
   xkcd-dl --update-db
-  xkcd-dl --download-latest
-  xkcd-dl --download=XKCDNUMBER
-  xkcd-dl --download-all
-  xkcd-dl --download-range <START> <END>
+  xkcd-dl --download-latest [--path=PATH]
+  xkcd-dl --download=XKCDNUMBER [--path=PATH]
+  xkcd-dl --download-all [--path=PATH]
+  xkcd-dl --download-range <START> <END> [--path=PATH]
   xkcd-dl --version
   xkcd-dl (-h | --help)
 Options:
@@ -29,7 +29,7 @@ from os import getcwd
 __author__ = "Tasdik Rahman (https://github.com/prodicus)"
 __version__ = '0.0.6'
 
-HOME =expanduser("~")       ## is cross platform. 'HOME' stores the path to the home directory for the current user
+HOME = expanduser("~")       ## is cross platform. 'HOME' stores the path to the home directory for the current user
 BASE_URL = 'http://xkcd.com'
 ARCHIVE_URL='http://xkcd.com/archive/'
 xkcd_dict_filename = '.xkcd_dict.json'
@@ -42,9 +42,8 @@ arguments = docopt(__doc__, version=__version__)
 #####  --download-all STARTS
 def download_all():
     '''
-    The command to download all the XKCD's and stores them in apporopriate folders.
+    The command to download all the XKCD's and stores them in appropriate folders.
     '''
-
     json_content = read_dict()
     if json_content:
         print("Downloading all xkcd's Till date!!")
@@ -323,6 +322,20 @@ url = {url}
     else: 
         print("{} does not exist! Please try with a different option".format(xkcd_number))
 
+def set_custom_path():
+    '''Changes the working directory path to a user-specified directory'''
+    path_was_set = False
+    if arguments["--path"] and os.path.isdir(arguments["--path"]):
+        # If we didn't change the directory,
+        # the user would only be able to use absolute paths
+        # That is, --path=./anything would fail
+        os.chdir(arguments["--path"])
+
+        global WORKING_DIRECTORY #Only ever changed here. Works fine as global.
+        WORKING_DIRECTORY = os.getcwd()
+        path_was_set = True
+    return path_was_set
+
 
 ##### Utility functions end
         
@@ -334,7 +347,13 @@ def main():
     '''
     if arguments['--update-db']:
         update_dict()
-    elif arguments['--download-latest']:
+
+    if arguments['--path']:
+        path_was_set = set_custom_path()
+        if not path_was_set:
+            print("The path could not be set. (The directory must exist. Was a directory name too long or null?)")
+            return
+    if arguments['--download-latest']:
         download_latest()
     elif arguments['--download']:
         download_xkcd_number()


### PR DESCRIPTION
This does not create any directories if the path does not exist, but that could be a potential feature as a different option. For my own comic archiver, I used a --pathc=PATH for that.